### PR TITLE
Don't use caches if building tagged version

### DIFF
--- a/dockci/models/build.py
+++ b/dockci/models/build.py
@@ -383,11 +383,15 @@ class Build(Model):  # pylint:disable=too-many-instance-attributes
 
             return False
 
+        # Don't use the docker caches if a version tag is defined
+        no_cache = (self.version is not None)
+
         return self._run_docker(
             'build',
             # saved stream for debugging
             # lambda: open('docker_build_stream', 'r'),
             lambda: self.docker_client.build(path=workdir,
+                                             nocache=no_cache,
                                              rm=True,
                                              stream=True),
             on_done=on_done,


### PR DESCRIPTION
https://trello.com/c/gJqwnpqL

If building a tagged version, then we'd like a completely fresh build in docker.
This will allow builds to have the latest from any upstream sources in yum, apt, etc.