### PR TITLE
Always return 'True' from _run_tag_version

### DIFF
--- a/dockci/models/build.py
+++ b/dockci/models/build.py
@@ -356,7 +356,10 @@ class Build(Model):  # pylint:disable=too-many-instance-attributes
                 if re.match(r'^v\d+\.\d+\.\d+$', line):
                     self.version = line
                     self.save()
-                    return True
+                # Always return 'True', else non-re.match'd tags will
+                # result in a return value of 'None'
+                # As noted above, stage result is irrelevant
+                return True
 
         except KeyError:
             # TODO remove spoofed return


### PR DESCRIPTION
If the re.match encounters something other than vX.Y.Z, this would
return 'None' - which resulted in the build aborting.

Fix so that the function always returns 'True'.

https://trello.com/c/DGqVi3Bk