### PR TITLE
Improve caching

### DIFF
--- a/dockci/exceptions.py
+++ b/dockci/exceptions.py
@@ -10,6 +10,13 @@ class InvalidOperationError(Exception):
     pass
 
 
+class AlreadyBuiltError(Exception):
+    """
+    Raised when a versioned build already exists in the repository
+    """
+    pass
+
+
 class AlreadyRunError(InvalidOperationError):
     """
     Raised when a build or stage is attempted to be run that has already been

--- a/dockci/models/build.py
+++ b/dockci/models/build.py
@@ -342,10 +342,11 @@ class Build(Model):  # pylint:disable=too-many-instance-attributes
         """
         stage = self._stage(
             'git_tag', workdir=workdir,
-            cmd_args=['git', 'describe', '--tags']
+            cmd_args=['git', 'describe', '--tags', '--exact-match']
         )
         if not stage.returncode == 0:
             # TODO remove spoofed return
+            # (except that --exact-match legitimately returns 128 if no tag)
             return True  # stage result is irrelevant
 
         try:

--- a/dockci/models/build.py
+++ b/dockci/models/build.py
@@ -21,7 +21,7 @@ from dockci.exceptions import AlreadyRunError
 from dockci.models.job import Job
 # TODO fix and reenable pylint check for cyclic-import
 from dockci.server import APP, CONFIG
-from dockci.util import bytes_human_readable, stream_write_status
+from dockci.util import bytes_human_readable, is_semantic, stream_write_status
 from dockci.yaml_model import LoadOnAccess, Model, OnAccess
 
 
@@ -186,16 +186,6 @@ class Build(Model):  # pylint:disable=too-many-instance-attributes
             for name, path in output_files
             if os.path.isfile(path)
         }
-
-    @classmethod
-    def _is_semantic(cls, tag):
-        """
-        Returns True if tag contains a semantic version number prefixed with a
-        lowercase v.  e.g. v1.2.3 returns True
-        """
-        # TODO maybe this could be a configuable regex for different
-        # versioning schemes?  (yyyymmdd for example)
-        return re.match(r'^v\d+\.\d+\.\d+$', tag) is not None
 
     def data_file_path(self):
         # Add the job name before the build slug in the path
@@ -412,7 +402,7 @@ class Build(Model):  # pylint:disable=too-many-instance-attributes
 
             if existing_image is not None:
                 # Do not override existing builds of _versioned_ tagged code
-                if self._is_semantic(self.version):
+                if is_semantic(self.version):
                     raise AlreadyBuiltError(
                         'Version %s of %s already built' % (
                             self.version,

--- a/dockci/models/build.py
+++ b/dockci/models/build.py
@@ -195,7 +195,7 @@ class Build(Model):  # pylint:disable=too-many-instance-attributes
         """
         # TODO maybe this could be a configuable regex for different
         # versioning schemes?  (yyyymmdd for example)
-        return (re.match(r'^v\d+\.\d+\.\d+$', tag) is not None)
+        return re.match(r'^v\d+\.\d+\.\d+$', tag) is not None
 
     def data_file_path(self):
         # Add the job name before the build slug in the path
@@ -428,7 +428,7 @@ class Build(Model):  # pylint:disable=too-many-instance-attributes
                         self.docker_client.remove_image(
                             image=existing_image['Id'],
                         )
-                    except docker.APIError:
+                    except docker.errors.APIError:
                         # TODO handle deletion of containers here
                         pass
 

--- a/dockci/models/build.py
+++ b/dockci/models/build.py
@@ -411,7 +411,6 @@ class Build(Model):  # pylint:disable=too-many-instance-attributes
                     break
 
             if existing_image is not None:
-
                 # Do not override existing builds of _versioned_ tagged code
                 if self._is_semantic(self.version):
                     raise AlreadyBuiltError(
@@ -420,7 +419,6 @@ class Build(Model):  # pylint:disable=too-many-instance-attributes
                             self.job_slug,
                         )
                     )
-
                 # Delete existing builds of _non-versioned_ tagged code
                 # (allows replacement of images)
                 else:

--- a/dockci/models/build.py
+++ b/dockci/models/build.py
@@ -364,7 +364,7 @@ class Build(Model):  # pylint:disable=too-many-instance-attributes
             data_file_path = os.path.join(*stage.data_file_path())
             with open(data_file_path, 'r') as handle:
                 line = handle.readline().strip()
-                if not line == '':
+                if not line:
                     self.version = line
                     self.save()
 

--- a/dockci/models/build.py
+++ b/dockci/models/build.py
@@ -358,7 +358,6 @@ class Build(Model):  # pylint:disable=too-many-instance-attributes
                 if re.match(r'^v\d+\.\d+\.\d+$', line):
                     self.version = line
                     self.save()
-                    return True
 
         except KeyError:
             pass

--- a/dockci/util.py
+++ b/dockci/util.py
@@ -5,6 +5,7 @@ import hashlib
 import hmac
 import logging
 import os
+import re
 import socket
 import struct
 
@@ -96,3 +97,13 @@ def stream_write_status(handle, status, success, fail):
     except Exception:  # pylint:disable=broad-except
         handle.write((" %s\n" % fail).encode())
         raise
+
+
+def is_semantic(version):
+    """
+    Returns True if tag contains a semantic version number prefixed with a
+    lowercase v.  e.g. v1.2.3 returns True
+    """
+    # TODO maybe this could be a configuable regex for different
+    # versioning schemes?  (yyyymmdd for example)
+    return re.match(r'^v\d+\.\d+\.\d+$', version) is not None


### PR DESCRIPTION
Implemented proposed design (from https://trello.com/c/GRfqlKmp):
- If code is not explicitly tagged, then it is built, tested, and then the image is removed
- If code is tagged with a semantic version (vX.Y.Z), then it will:
  - Check if version has been built before:
    - If yes: abort
    - If no: build, test and keep the resulting image
- If code is tagged with anything other than a semantic version, then it will:
  - Check if a build had the same tag previously:
    - If yes: remove the existing image
    - If no: proceed
  - Then proceeds to build, test and keep the resulting image

https://trello.com/c/GRfqlKmp