### PR TITLE
Fix spliting lines on stream structs, rather than \n

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Forms are validated for model integrity #21
 - Added auto scroll button to build pages #22
 - Auto scroll off by default #22
+- Console line splitting fixed #23
 
 ## v0.0.2
 - Streaming console #16

--- a/dockci/templates/build.html
+++ b/dockci/templates/build.html
@@ -168,11 +168,18 @@
         panelEl.toggleClass('panel-info panel-danger');
 
       } else if ('stream' in obj) {
-        logEl.append(
-          '<div class="docker-log-stream">' +
-          ansi_up.ansi_to_html(obj['stream']) +
-          '</div>'
-        );
+
+        lineEl = $('.docker-log-stream:last', logEl);
+        if (lineEl.length === 0) {
+          lineEl = $('<div class="docker-log-stream"></div>');
+          logEl.append(lineEl);
+        }
+
+        lineEl.html(lineEl.html() + ansi_up.ansi_to_html(obj['stream']));
+
+        if (obj['stream'].endsWith('\n')) {
+          logEl.append('<div class="docker-log-stream"></div>');
+        }
 
       } else if ('id' in obj) {
         idRow = $('.docker-log-' + obj['id'], logEl);


### PR DESCRIPTION
https://trello.com/c/fo9PRZAh/53-bug-console-lines-split

Docker stream lines in the docker build JSON aren't necessary 1 line per stream statement, but the console treats them as such. They should create new lines only when the last char is `\n`, which we currently ignore.