### PR TITLE
Remove DEBIAN_MIRROR overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Upgrade YAML model #146
 - Fix email #147
 - Add users, related UI, protect some forms #147
+- Remove DEBIAN_MIRROR override #150
 
 ## v0.0.3
 - Log level to debug #20

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,6 @@ ENTRYPOINT ["/usr/bin/make"]
 CMD ["run"]
 
 ENV DEBIAN_FRONTEND noninteractive
-ENV DEBIAN_MIRROR http://mirror.linux.org.au/debian
-RUN echo "deb $DEBIAN_MIRROR jessie main"                     >  /etc/apt/sources.list && \
-    echo "deb $DEBIAN_MIRROR jessie-updates main"             >> /etc/apt/sources.list && \
-    echo "deb http://security.debian.org jessie/updates main" >> /etc/apt/sources.list
 RUN apt-get update && apt-get install -y aria2 && \
     aria2c -d /tmp "https://raw.githubusercontent.com/RickyCook/minimal-apt-fast/5750510/install.sh" && \
     APT_FAST_VERSION=v1.7.6 NO_APT_UPDATE=y sh -e /tmp/install.sh && \


### PR DESCRIPTION
Debian mirror is broken. It's unnecessary anyway