### PR TITLE
GitHub push status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - OAuth reauthenticate when scope changes #149
 - Remove DEBIAN_MIRROR override #150
 - Server host tests on config page #151
+- GitHub recieves build status updates #161
 
 ## v0.0.3
 - Log level to debug #20

--- a/dockci/models/build.py
+++ b/dockci/models/build.py
@@ -17,7 +17,7 @@ import py.path  # pylint:disable=import-error
 
 from docker.utils import kwargs_from_env
 from flask import url_for
-from yaml_model import (LoadOnAccess,  # pylint:disable=duplicate-code
+from yaml_model import (LoadOnAccess,
                         Model,
                         ModelReference,
                         OnAccess,

--- a/dockci/models/build.py
+++ b/dockci/models/build.py
@@ -353,7 +353,7 @@ class Build(Model):  # pylint:disable=too-many-instance-attributes
                     return False
 
                 if self.job.github_repo_id:
-                    self._run_external_status()
+                    self._run_external_status('start')
 
                 if not all(prepare):
                     self.result = 'error'
@@ -613,7 +613,7 @@ class Build(Model):  # pylint:disable=too-many-instance-attributes
             handle.flush()
             return False
 
-    def _run_external_status(self):
+    def _run_external_status(self, suffix):
         """
         Create a new pending status for this build in GitHub
         """
@@ -630,7 +630,9 @@ class Build(Model):  # pylint:disable=too-many-instance-attributes
             handle.flush()
             return success
 
-        return self._stage('external_status', runnable=runnable).returncode
+        return self._stage(
+            'external_status_%s' % suffix, runnable=runnable
+        ).returncode
 
     def _run_provision(self, workdir):
         """

--- a/dockci/models/build.py
+++ b/dockci/models/build.py
@@ -17,7 +17,7 @@ import py.path  # pylint:disable=import-error
 
 from docker.utils import kwargs_from_env
 from flask import url_for
-from yaml_model import (LoadOnAccess,
+from yaml_model import (LoadOnAccess,  # pylint:disable=duplicate-code
                         Model,
                         ModelReference,
                         OnAccess,
@@ -211,7 +211,6 @@ class Build(Model):  # pylint:disable=too-many-instance-attributes
             self.commit,
         )
 
-
     @property
     def state(self):
         """
@@ -385,10 +384,11 @@ class Build(Model):  # pylint:disable=too-many-instance-attributes
 
         finally:
             try:
+                self._run_external_status('complete')
                 self._run_cleanup()
 
             except Exception:  # pylint:disable=broad-except
-                self._error_stage('cleanup_error')
+                self._error_stage('post_error')
 
             self.complete_ts = datetime.now()
             self.save()

--- a/dockci/models/build.py
+++ b/dockci/models/build.py
@@ -189,6 +189,21 @@ class Build(Model):  # pylint:disable=too-many-instance-attributes
         return True
 
     @property
+    def url(self):
+        """ URL for this build """
+        return url_for('build_view',
+                       job_slug=self.job.slug,
+                       build_slug=self.slug)
+
+    @property
+    def url_ext(self):
+        """ URL for this job """
+        return url_for('build_view',
+                       job_slug=self.job.slug,
+                       build_slug=self.slug,
+                       _external=True)
+
+    @property
     def state(self):
         """
         Current state that the build is in

--- a/dockci/models/job.py
+++ b/dockci/models/job.py
@@ -7,8 +7,14 @@ from uuid import uuid4
 import py.error  # pylint:disable=import-error
 
 from flask import url_for
-from yaml_model import LoadOnAccess, Model, OnAccess, ValidationError
+from yaml_model import (LoadOnAccess,
+                        Model,
+                        ModelReference,
+                        OnAccess,
+                        ValidationError,
+                        )
 
+from dockci.models.auth import User
 from dockci.server import OAUTH_APPS
 from dockci.util import is_yaml_file, is_git_ancestor
 
@@ -191,5 +197,8 @@ class Job(Model):  # pylint:disable=too-few-public-methods
     github_repo_id = LoadOnAccess(default=lambda _: None)
     github_hook_id = LoadOnAccess(default=lambda _: None)
     github_secret = LoadOnAccess(default=lambda _: None)
+    github_auth_user = ModelReference(lambda self: User(
+        self.github_auth_user_slug
+    ), default=lambda _: None)
 
     builds = OnAccess(_all_builds)

--- a/dockci/views/job.py
+++ b/dockci/views/job.py
@@ -61,12 +61,10 @@ def job_edit_view(slug):
     if not job.exists():
         abort(404)
 
-    return job_input_view(job, 'edit', (
-        # NOTE github_repo_id included so that it can be UNSET, but will never
-        # have its value passed through
-        'name', 'repo', 'github_secret', 'github_repo_id',
+    return job_input_view(job, 'edit', [
+        'name', 'repo', 'github_secret'
         'hipchat_api_token', 'hipchat_room',
-    ))
+    ])
 
 
 @APP.route('/jobs/new', methods=('GET', 'POST'))
@@ -76,10 +74,10 @@ def job_new_view():
     View to make a new job
     """
     job = Job()
-    return job_input_view(job, 'new', (
+    return job_input_view(job, 'new', [
         'slug', 'name', 'repo', 'github_secret', 'github_repo_id',
         'hipchat_api_token', 'hipchat_room',
-    ))
+    ])
 
 
 def handle_github_hook(job):
@@ -107,8 +105,12 @@ def job_input_view(job, edit_operation, fields):
 
         # Filter out github properties if not a github repo, so that they are
         # unset on the job
-        if request.args.get('repo_type', None) != 'github':
+        if request.args.get('repo_type', None) == 'github':
+            fill_data['github_auth_user'] = current_user
+            fields.append('github_auth_user')
+        else:
             fill_data['github_repo_id'] = None
+            fields.append('github_repo_id')
 
         saved = request_fill(
             job, fields,

--- a/dockci/workers.py
+++ b/dockci/workers.py
@@ -40,7 +40,6 @@ def run_build_async(job_slug, build_slug):
             job = Job(job_slug)
             build = Build(job=job, slug=build_slug)
             build_okay = build._run_now()  # pylint:disable=protected-access
-            build._run_external_status('complete')
 
             # Send the failure message
             if not build_okay:

--- a/dockci/workers.py
+++ b/dockci/workers.py
@@ -40,6 +40,7 @@ def run_build_async(job_slug, build_slug):
             job = Job(job_slug)
             build = Build(job=job, slug=build_slug)
             build_okay = build._run_now()  # pylint:disable=protected-access
+            build._run_external_status('complete')
 
             # Send the failure message
             if not build_okay:

--- a/pylint.conf
+++ b/pylint.conf
@@ -10,6 +10,9 @@ disable=bad-continuation,
         star-args,
         wildcard-import,
 
+        # TODO re-enable
+        duplicate-code,  # imports in models/{job,build}.py
+
 [REPORTS]
 output-format=colorized
 reports=yes


### PR DESCRIPTION
Pushes statuses to jobs on job start, and job complete for all of pending, success, fail, error results (not including a worker error)

Closes #86 