### PR TITLE
Better docker exception

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,9 @@ deps: htmldeps pythondeps collectstatic
 styletest:  # don't install deps
 	python_env/bin/pep8 dockci
 	python_env/bin/pylint --rcfile pylint.conf dockci
+unittest: export PYTHONPATH = $(shell pwd)
 unittest:
-	python_env/bin/py.test -vv test
+	python_env/bin/py.test -vv tests
 test: testdeps styletest unittest
 
 # Container commands

--- a/dockci/exceptions.py
+++ b/dockci/exceptions.py
@@ -2,7 +2,8 @@
 DockCI exceptions
 """
 
-from requests.exceptions import ConnectionError
+import requests.exceptions
+
 from requests.packages.urllib3.exceptions import ProtocolError
 
 
@@ -43,6 +44,7 @@ class AlreadyRunError(InvalidOperationError):
 class DockerUnreachableError(Exception, HumanOutputException):
     """ Raised when Docker is unreachable for some reason """
     def __init__(self, client, exception, message=None):
+        super(DockerUnreachableError, self).__init__()
         self.client = client
         self.exception = exception
         self.message = message
@@ -69,7 +71,7 @@ class DockerUnreachableError(Exception, HumanOutputException):
         if exception is None:
             raise ValueError("No exception given")
 
-        if isinstance(exception, ConnectionError):
+        if isinstance(exception, requests.exceptions.ConnectionError):
             return self.root_exception(exception.args[0])
         if isinstance(exception, ProtocolError):
             return self.root_exception(exception.args[1])

--- a/dockci/exceptions.py
+++ b/dockci/exceptions.py
@@ -7,7 +7,7 @@ import requests.exceptions
 from requests.packages.urllib3.exceptions import ProtocolError
 
 
-class HumanOutputException(object):
+class HumanOutputError(object):
     """
     Mixin for an Exception that can be handled by user output of the string
     repr
@@ -41,7 +41,7 @@ class AlreadyRunError(InvalidOperationError):
         self.runnable = runnable
 
 
-class DockerUnreachableError(Exception, HumanOutputException):
+class DockerUnreachableError(Exception, HumanOutputError):
     """ Raised when Docker is unreachable for some reason """
     def __init__(self, client, exception, message=None):
         super(DockerUnreachableError, self).__init__()

--- a/dockci/models/job_meta/stages.py
+++ b/dockci/models/job_meta/stages.py
@@ -5,7 +5,9 @@ Stages in a Job
 import logging
 import subprocess
 
-from dockci.exceptions import AlreadyRunError
+from requests.exceptions import ConnectionError
+
+from dockci.exceptions import AlreadyRunError, DockerUnreachableError
 
 
 class JobStageBase(object):
@@ -168,7 +170,10 @@ class DockerStage(JobStageBase):
         """
         Perform the Docker command given
         """
-        output = self.runnable_docker()
+        try:
+            output = self.runnable_docker()
+        except ConnectionError as ex:
+            raise DockerUnreachableError(self.job.docker_client, ex)
 
         if not output:
             return 0

--- a/dockci/models/job_meta/stages.py
+++ b/dockci/models/job_meta/stages.py
@@ -5,7 +5,7 @@ Stages in a Job
 import logging
 import subprocess
 
-from requests.exceptions import ConnectionError
+import requests.exceptions
 
 from dockci.exceptions import AlreadyRunError, DockerUnreachableError
 
@@ -172,7 +172,7 @@ class DockerStage(JobStageBase):
         """
         try:
             output = self.runnable_docker()
-        except ConnectionError as ex:
+        except requests.exceptions.ConnectionError as ex:
             raise DockerUnreachableError(self.job.docker_client, ex)
 
         if not output:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,3 +1,4 @@
+import docker
 import pytest
 
 from requests.exceptions import ConnectionError
@@ -42,15 +43,37 @@ class TestDockerUnreachableError(object):
         ex_info = pytest.raises(ValueError, test_ex.root_exception)
 
     @pytest.mark.parametrize('args,expected', [
-        ((None, None, 'testing'), 'testing'),
-        ((None, ValueError('different'), 'testing'), 'testing'),
-        ((None, CONN_REFUSED), '[Errno 61] Connection refused'),
-        ((None, ValueError('testing')), 'testing'),
         (
-            (None, ConnectionError(ProtocolError(
-                'Connection aborted.', CONN_REFUSED,
-            ))),
-            '[Errno 61] Connection refused',
+            (docker.Client('http://localhost:2375'), None, 'testing'),
+            "Error with the Docker server 'http://localhost:2375': testing",
+        ),
+        (
+            (
+                docker.Client('http://localhost:2375'),
+                ValueError('different'),
+                'testing',
+            ),
+            "Error with the Docker server 'http://localhost:2375': testing",
+        ),
+        (
+            (docker.Client('http://localhost:2375'), CONN_REFUSED),
+            "Error with the Docker server 'http://localhost:2375': "
+            "[Errno 61] Connection refused",
+        ),
+        (
+            (
+                docker.Client('http://localhost:2375'),
+                ValueError('testing'),
+            ),
+            "Error with the Docker server 'http://localhost:2375': testing",
+        ),
+        (
+            (
+                docker.Client('http://localhost:2375'), ConnectionError(
+                    ProtocolError('Connection aborted.', CONN_REFUSED))
+            ),
+            "Error with the Docker server 'http://localhost:2375': "
+            "[Errno 61] Connection refused",
         ),
     ])
     def test_str(self, args, expected):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,62 @@
+import pytest
+
+from requests.exceptions import ConnectionError
+from requests.packages.urllib3.exceptions import ProtocolError
+
+from dockci.exceptions import *
+
+
+CONN_REFUSED = ConnectionRefusedError(61, 'Connection refused')
+
+
+class TestDockerUnreachableError(object):
+    """ Test ``DockerUnreachableError`` class """
+    @pytest.mark.parametrize('exception,expected', [
+        (ValueError('test error'), ValueError),
+        (CONN_REFUSED, ConnectionRefusedError),
+        (
+            ProtocolError('Connection aborted.', CONN_REFUSED),
+            ConnectionRefusedError
+        ),
+        (
+            ConnectionError(ProtocolError(
+                'Connection aborted.', CONN_REFUSED,
+            )),
+            ConnectionRefusedError
+        ),
+    ])
+    def test_root_exception(self, exception, expected):
+        """
+        Ensure that the ``root_exception`` method returns the correct
+        exceptions as the root
+        """
+        test_ex = DockerUnreachableError(None, exception)
+        assert test_ex.root_exception().__class__ == expected
+
+    def test_root_exception_no_exception(self):
+        """
+        Ensure that ``root_exception`` method raises ``ValueError`` when no
+        exception is given to init, or param
+        """
+        test_ex = DockerUnreachableError(None, None)
+        ex_info = pytest.raises(ValueError, test_ex.root_exception)
+
+    @pytest.mark.parametrize('args,expected', [
+        ((None, None, 'testing'), 'testing'),
+        ((None, ValueError('different'), 'testing'), 'testing'),
+        ((None, CONN_REFUSED), '[Errno 61] Connection refused'),
+        ((None, ValueError('testing')), 'testing'),
+        (
+            (None, ConnectionError(ProtocolError(
+                'Connection aborted.', CONN_REFUSED,
+            ))),
+            '[Errno 61] Connection refused',
+        ),
+    ])
+    def test_str(self, args, expected):
+        """
+        Ensure that messages are retrieved from root exceptions, and overridden
+        by init message as expected
+        """
+        test_ex = DockerUnreachableError(*args)
+        assert str(test_ex) == expected


### PR DESCRIPTION
When docker-py throws things like `TimeoutError`, etc this will display just the error, along side the offending connection URL rather than a full traceback (which is unhelpful). Also leads to much more useful error messages for debugging purposes, as the original exception isn't obfuscated 

Fixes #171