### PR TITLE
Fix significant browser load for error stages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+### v0.0.6
+- Significant decrease in browser load on jobs with error stage #215
+
 ### v0.0.5 (Breaking)
 - **BREAKING** Force project slugs to comply with Docker regex #192
   - All slugs will be lower-cased

--- a/dockci/templates/job.html
+++ b/dockci/templates/job.html
@@ -153,11 +153,7 @@
         }
       })
 
-      if (idx == 0) {
-        $('#job-stages').append(created);
-      } else {
-        created.insertAfter($('#job-stages').children()[idx - 1]);
-      }
+      $('#job-stages').append(created);
 
       return created
     }


### PR DESCRIPTION
Error stages used to get into an infinite loop, and make the entire browser unresponsive in a matter of seconds